### PR TITLE
Firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ Ever happened that while reading a long article, you cannot concentrate and read
 
 ## Installation
 
-Type2Learn can be found on the Chrome store [here](https://chrome.google.com/webstore/detail/type2learn/fhaenfmnpmhafnbamailokcjjbpmehig)
+### Chrome(-ium)
+Type2Learn can be found on the Chrome store [here](https://chrome.google.com/webstore/detail/type2learn/fhaenfmnpmhafnbamailokcjjbpmehig)!
+
+Alternatively, you can also install the extension locally:
+1. Clone the repo or download the files in a .zip-file and unpack it into any folder
+2. Follow the Instructions listed [here](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) (might slightly vary if you use any other Chromium browser)
+
+### Firefox
+Currently, the only way to use the extension on Firefox is to sign it yourself:
+1. Clone the repo or download the files in a .zip-file and unpack it into any folder
+2. Delete `manifest.json` and rename `manifest_firefox.json` to `manifest.json`
+2. Follow the Instructions for sideloading an extension [here](https://extensionworkshop.com/documentation/publish/distribute-sideloading/)
 
 ## Demo
 

--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@ chrome.runtime.onInstalled.addListener((reason) => {
 });
 
 // console.log("background running");
-chrome.browserAction.onClicked.addListener(setup);
+chrome.action.onClicked.addListener(setup);
 
 function setup() {
   noCanvas();

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.4",
   "manifest_version": 3,
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "permissions": ["storage", "activeTab", "scripting"],
   "content_scripts": [
@@ -14,10 +14,6 @@
       "css": ["my-styles.css"]
     }
   ],
-  "browser_action" : {
-    "default_popup" : "popup.html",
-    "default_title" : "Type2Learn"
- },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -4,7 +4,7 @@
   "version": "0.0.4",
   "manifest_version": 3,
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "permissions": ["storage", "activeTab", "scripting"],
   "content_scripts": [

--- a/span-text.js
+++ b/span-text.js
@@ -14,15 +14,15 @@ for (para of paragraphs) {
     characterSpans.push.apply(characterSpans, arrayTmpSpans)
 }
 
-if (window.getSelection) {
-    let sel = window.getSelection()
-    sel.anchorNode.parentElement.classList.add('current_character')
-    if (window.getSelection().empty) {  // Chrome
-      window.getSelection().empty();
-    } else if (window.getSelection().removeAllRanges) {  // Firefox
-      window.getSelection().removeAllRanges();
+if (window.getSelection().anchorNode != null) {
+    let sel = window.getSelection().anchorNode
+    // sel.anchorNode.parentElement.classList.add('current_character')
+    if (sel.nodeName == "#text") { // Chrome(-ium)
+        sel.parentElement.classList.add('current_character')
+    } else if (sel.nodeName == "P") { // Firefox: For some reason, getSelection() doesn't select the #text-node but the paragraph its surrounded in
+        sel.childNodes[0].classList.add('current_character');
     }
-} else {  // IE?
+} else {  // If no paragraph was selected
     if (characterSpans.length > 0) {
         characterSpans[0].classList.add('current_character')
     }


### PR DESCRIPTION
Hello!

I really like your browser extension and found it to be a super cool idea! However, since it was only available on the Chrome Web Store, and I mainly use Firefox, I wanted to know if it runs on Firefox.
I noticed that one thing prevented the extension from working on Firefox as well:

- Firefox behaves a bit differently than Chrome(-ium), when it comes to text selection. For some reason, on Chrome(-ium) `sel.anchorNode` would point towards a `#text`-node, while on Firefox, it would point to the `p`-node. This caused the `current_character` class to applied to the `<body>` tag instead of the character class.

So I went ahead and adjusted this. I also made it possible to start typing, even when no text has been selected before.

There is one problem tho: Firefox doesn't support the `background.service_worker` key in the `manifest.json` file, but still the old `background.scripts` key. While I have changed the manifest to the firefox supported way, this now means that there have to be two different manifests for Chrome(-ium) and Firefox.

I hope that these edits are helpful. This is my first time working with existing browser exstensions _and_ contributing to open souce software on Github! 😅